### PR TITLE
feat: notifications hook for comment + reaction (posts → notifications 연동)

### DIFF
--- a/apps/notifications/services.py
+++ b/apps/notifications/services.py
@@ -1,16 +1,23 @@
-from notification.models import Notification
-from users.models import User
+# posts 통합을 위한 fetch(260116)
+#추가
+from typing import Optional
+#추가
+from django.contrib.auth import get_user_model
+from notifications.models import Notification
+# 제거: from users.models import User
 from posts.models import Post
-from posts.models import Comment
+# 제거: from posts.models import Comment
 from events.models import Event
+
+User = get_user_model()
 
 def create_notification(
     user: User,
     type: str,
     message: str,
-    relate_url: str = None,
-    post: Post = None,
-    event: Event = None
+    relate_url: Optional[str] = None,
+    post: Optional[Post] = None,
+    event: Optional[Event] = None,
 ):
     """
     user: 알림을 생성할 User 객체


### PR DESCRIPTION
## 변경 사항
### 댓글 알림 (Comment)
- 대상: 내 게시글에 다른 유저가 댓글 작성 시 → 게시글 작성자에게 알림 생성
- 외: 자기 글에 자기 댓글은 알림 생성하지 않음
- relate_url: /posts/{post_id}#comment-{comment_id} (FE가 바로 앵커 이동 가능)

### 좋아요/싫어요 알림 (Reaction)
- 대상: 내 게시글에 다른 유저가 좋아요/싫어요 누른 경우 → 게시글 작성자에게 알림 생성
- 예외:
    - 자기 글에 자기 반응은 알림 생성하지 않음
    - 토글로 취소된 경우(new_state = None)는 알림 생성하지 않음

- 알림 타입:
   - like → post_like
   - dislike → post_dislike

## 파일 변경
- apps/posts/views.py
  - `comment_create()` : 댓글 알림 hook 추가
  - `_toggle_reaction()` : like/dislike 알림 hook 추가

- apps/notifications/services.py
  - create_notification 헬퍼 import 경로 정리/통합

알림 생성은 메인 트랜잭션과 분리:
- 댓글/리액션 성공 후에만 실행
- 알림 생성 실패해도 API 성공 응답 유지

## 영향 범위
- 기존 API 스펙 변경 X
- 다음 수행 시 **/api/notifications 목록에서 신규 알림 생성**
```
POST /api/posts/<post_id>/comments

POST /api/posts/<post_id>/reactions/like

POST /api/posts/<post_id>/reactions/dislike
```