### PR TITLE
feat: uploads presign API + include group_name in responses

### DIFF
--- a/apps/uploads/apps.py
+++ b/apps/uploads/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UploadsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "uploads"

--- a/apps/uploads/services.py
+++ b/apps/uploads/services.py
@@ -1,0 +1,71 @@
+import re
+import uuid
+from datetime import datetime, timezone
+
+import boto3
+from botocore.config import Config
+
+
+_FILENAME_SAFE_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def _safe_filename(filename: str) -> str:
+    name = (filename or "").strip()
+    if not name:
+        return "file"
+
+    # 경로 제거
+    name = name.split("/")[-1].split("\\")[-1]
+
+    # 너무 긴 파일명 방지
+    name = name[:120]
+
+    # 안전 문자만 남기기
+    name = _FILENAME_SAFE_RE.sub("_", name).strip("._")
+    return name or "file"
+
+
+def build_object_key(prefix: str, user_id: int, filename: str) -> str:
+    # prefix 정규화
+    p = (prefix or "uploads/").strip()
+    if not p.endswith("/"):
+        p += "/"
+
+    safe = _safe_filename(filename)
+    now = datetime.now(timezone.utc)
+    date_path = now.strftime("%Y/%m/%d")
+    uid = uuid.uuid4().hex
+    return f"{p}{user_id}/{date_path}/{uid}_{safe}"
+
+
+def make_public_url(bucket: str, region: str, key: str, public_base_url: str | None = None) -> str:
+    if public_base_url:
+        base = public_base_url.rstrip("/")
+        return f"{base}/{key}"
+    # virtual-hosted–style
+    return f"https://{bucket}.s3.{region}.amazonaws.com/{key}"
+
+
+def generate_presigned_put_url(
+    *,
+    bucket: str,
+    region: str,
+    key: str,
+    expires_in: int,
+) -> str:
+    # role 기반 기본 credential chain 사용(EC2 IAM Role)
+    client = boto3.client(
+        "s3",
+        region_name=region,
+        config=Config(signature_version="s3v4"),
+    )
+
+    return client.generate_presigned_url(
+        ClientMethod="put_object",
+        Params={
+            "Bucket": bucket,
+            "Key": key,
+        },
+        ExpiresIn=expires_in,
+        HttpMethod="PUT",
+    )

--- a/apps/uploads/views.py
+++ b/apps/uploads/views.py
@@ -1,0 +1,106 @@
+import json
+
+from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from common.utils import common_response, login_check
+from .services import build_object_key, generate_presigned_put_url, make_public_url
+
+
+def _parse_json(request):
+    try:
+        return json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return None
+
+
+def _is_allowed_image(content_type: str, filename: str) -> bool:
+    ct = (content_type or "").strip().lower()
+    fn = (filename or "").strip().lower()
+
+    if not ct.startswith("image/"):
+        return False
+
+    # MVP: 최소 허용
+    allowed_ext = (".png", ".jpg", ".jpeg", ".webp")
+    if not any(fn.endswith(ext) for ext in allowed_ext):
+        return False
+
+    # ct(Content Type) 최소 제한
+    allowed_ct = ("image/png", "image/jpeg", "image/webp")
+    return ct in allowed_ct
+
+
+@csrf_exempt
+@login_check
+@require_POST
+def presign_upload(request):
+    """
+    POST /api/uploads/presign
+    Body:
+      {
+        "filename": "a.png",
+        "content_type": "image/png"
+      }
+
+    Response:
+      {
+        "upload": {
+          "method": "PUT",
+          "url": "...presigned..."
+        },
+        "key": "uploads/..../uuid_a.png",
+        "file_url": "https://bucket.s3.region.amazonaws.com/...",
+        "expires_in": 300
+      }
+    """
+    data = _parse_json(request)
+    if data is None:
+        return common_response(False, message="잘못된 JSON 형식입니다.", status=400)
+
+    filename = (data.get("filename") or "").strip()
+    content_type = (data.get("content_type") or "").strip()
+
+    if not filename or not content_type:
+        return common_response(False, message="filename/content_type는 필수입니다.", status=400)
+
+    if not _is_allowed_image(content_type, filename):
+        return common_response(False, message="이미지 업로드는 png/jpg/jpeg/webp만 허용됩니다.", status=400)
+
+    # settings에서 읽기(키 여러 개 fallback 지원)
+    bucket = getattr(settings, "S3_UPLOAD_BUCKET", "") or ""
+    region = getattr(settings, "AWS_REGION", "") or ""
+    prefix = getattr(settings, "S3_UPLOAD_PREFIX", "uploads/")
+    expires_in = int(getattr(settings, "S3_PRESIGN_EXPIRES", 300) or 300)
+    public_base_url = getattr(settings, "S3_PUBLIC_BASE_URL", None)
+
+    if not bucket or not region:
+        return common_response(False, message="S3 설정이 누락되었습니다.(bucket/region)", status=500)
+
+    key = build_object_key(prefix=prefix, user_id=request.user_id, filename=filename)
+
+    try:
+        presigned_url = generate_presigned_put_url(
+            bucket=bucket,
+            region=region,
+            key=key,
+            expires_in=expires_in,
+        )
+    except Exception:
+        return common_response(False, message="Presigned URL 생성에 실패했습니다.", status=500)
+
+    file_url = make_public_url(bucket=bucket, region=region, key=key, public_base_url=public_base_url)
+
+    resp = {
+        "upload": {
+            "method": "PUT",
+            "url": presigned_url,
+            # 서명에 강제하진 않음
+            "headers": {"Content-Type": content_type},
+        },
+        "key": key,
+        "file_url": file_url,  # DB에 저장할 “표시용 URL” (image_url)
+        "expires_in": expires_in,
+    }
+    return common_response(True, data=resp, message="Presign 발급 성공", status=200)

--- a/config/settings.py
+++ b/config/settings.py
@@ -13,18 +13,11 @@ environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
 SECRET_KEY = env('SECRET_KEY')
 DEBUG = env('DEBUG')
-db_mode = env('DB_MODE', default='sqlite')
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 
 KAKAO_REST_API_KEY = env('KAKAO_REST_API_KEY')
 KAKAO_REDIRECT_URI = env('KAKAO_REDIRECT_URI')
 KAKAO_ACCESS_TOKEN_CLIENT_SECRET = env('KAKAO_ACCESS_TOKEN_CLIENT_SECRET')
-NAVER_REST_API_KEY = env('NAVER_REST_API_KEY')
-NAVER_REDIRECT_URI = env('NAVER_REDIRECT_URI')
-NAVER_ACCESS_TOKEN_CLIENT_SECRET = env('NAVER_ACCESS_TOKEN_CLIENT_SECRET')
-GOOGLE_REST_API_KEY = env('GOOGLE_REST_API_KEY')
-GOOGLE_ACCESS_TOKEN_CLIENT_SECRET = env('GOOGLE_ACCESS_TOKEN_CLIENT_SECRET')
-GOOGLE_REDIRECT_URI = env('GOOGLE_REDIRECT_URI')
 
 # 2. 앱 설정 (DRF, SimpleJWT 제거)
 INSTALLED_APPS = [
@@ -44,12 +37,12 @@ INSTALLED_APPS = [
     'posts',
     'bookmarks',
     'notifications',
+    'uploads',
 ]
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware', # 최상단
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -77,32 +70,9 @@ TEMPLATES = [
 WSGI_APPLICATION = 'config.wsgi.application'
 
 # 3. 데이터베이스 (MariaDB)
-if db_mode == 'sqlite':
-    DATABASES = {
-        'default' : {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
-        }
-    }
-else:    
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'stagelog',
-            'USER': 'admin',
-            'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-            'HOST': os.environ.get('DB_HOST', ''),
-            'PORT': '3306',
-            'OPTIONS': {
-                'ssl': {
-                    'ca': None,#os.path.join(BASE_DIR, 'certs/global-bundle.pem'),
-                },
-                'ssl_mode': 'REQUIRED',
-                'charset': 'utf8mb4',
-            },
-        }
-    }
-
+DATABASES = {
+    'default': env.db(),
+}
 
 # 4. 커스텀 유저 모델
 AUTH_USER_MODEL = 'users.User' 
@@ -136,9 +106,17 @@ if not DEBUG:
 JWT_ALGORITHM = 'HS256'
 JWT_EXP_DELTA_SECONDS = env.int('JWT_EXP_DELTA_SECONDS', default= 60 * 30)
 
-# 10. 정적파일경로설정
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+# 10. AWS S3 (Presigned Upload)
+AWS_REGION = env("AWS_REGION", default=env("AWS_DEFAULT_REGION", default="ap-northeast-2"))
 
-# 11. ALB사용 시 리다이렉션 오류 방지
-# ALB가 전달해준 원래 호스트 정보를 신뢰합니다.
-USE_X_FORWARDED_HOST = True
+# 10-1. bucket 키는 여러 이름 fallback 지원
+S3_UPLOAD_BUCKET = env(
+    "S3_UPLOAD_BUCKET",
+    default=env("AWS_STORAGE_BUCKET_NAME", default=env("S3_BUCKET", default="")),
+)
+
+S3_UPLOAD_PREFIX = env("S3_UPLOAD_PREFIX", default="uploads/")
+S3_PRESIGN_EXPIRES = env.int("S3_PRESIGN_EXPIRES", default=300)
+
+# <-- (추후 커스텀 도메인/CloudFront 대응용, 여기에 base URL 지정) -->
+# S3_PUBLIC_BASE_URL = env("S3_PUBLIC_BASE_URL", default=None)

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,6 +20,7 @@ from django.urls import path, include
 from events import views as events_views
 from posts import views as posts_views
 from notifications import views as notifications_views
+from uploads import views as uploads_views
 from common.utils import health_check
 
 urlpatterns = [
@@ -50,5 +51,7 @@ urlpatterns = [
     path('api/notifications', notifications_views.get_notification_list, name='get_notification_list'),
     path('api/notifications/', include('notifications.urls')),
 
-    path('', health_check)
+    path('', health_check),
+
+    path("api/uploads/presign", uploads_views.presign_upload, name="presign_upload"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ sqlparse==0.5.5
 urllib3==2.6.2
 gunicorn==23.0.0
 whitenoise==6.6.0
+boto3==1.34.162
+botocore==1.34.162


### PR DESCRIPTION
### presign endpoint 경로:
- `POST /api/uploads/presign`

### 필요한 env 키 목록 (EC2 개발 서버 `.env` 내 포함 완료)
- AWS_REGION=
- AWS_DEFAULT_REGION=
- AWS_STORAGE_BUCKET_NAME=
- S3_BUCKET=
- S3_UPLOAD_BUCKET=
- S3_UPLOAD_PREFIX=

### 사용 방식(presign URL 받아 PUT 업로드 → DB에는 file_url 저장)
1. presign 응답의 `upload.url`로 S3에 PUT 업로드
2. 업로드 후, file_url을 posts.event_posts_create의 image_url로 저장

### 허용 타입: png/jpg/jpeg/webp

### prefix:
`uploads/{user_id}/YYYY/MM/DD/uuid_filename`