### PR TITLE
fix: STATIC_ROOT for collectstatic

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -91,7 +91,8 @@ TIME_ZONE = 'Asia/Seoul'
 USE_I18N = True
 USE_TZ = True
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # 7. Trailing Slash 제거
 APPEND_SLASH = False


### PR DESCRIPTION
EC2 컨테이너 시작 커맨드가 collectstatic -> migrate -> gunicorn 순서에 따른
Django settings 내
 STATIC_ROOT가 부재로 인한 collectstatic 단계의 크래시 이슈 수정