### PR TITLE
fix(config): enable S3_PUBLIC_BASE_URL for uploads file_url

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -156,5 +156,4 @@ S3_UPLOAD_BUCKET = env(
 S3_UPLOAD_PREFIX = env("S3_UPLOAD_PREFIX", default="uploads/")
 S3_PRESIGN_EXPIRES = env.int("S3_PRESIGN_EXPIRES", default=300)
 
-# <-- (추후 커스텀 도메인/CloudFront 대응용, 여기에 base URL 지정) -->
-# S3_PUBLIC_BASE_URL = env("S3_PUBLIC_BASE_URL", default=None)
+S3_PUBLIC_BASE_URL = env("S3_PUBLIC_BASE_URL", default=None)


### PR DESCRIPTION
### 변경 사항:
- settings.py에서 `S3_PUBLIC_BASE_URL` 활성화

### 변경 후 기대결과:
- S3 direct URL will 403